### PR TITLE
Adds Backend Logic to interactions with ZenodoAPI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,13 +47,21 @@ jobs:
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Set image tags
+        id: set-tags
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev" >> $GITHUB_ENV
+          else
+            echo "tags=${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
+          fi
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.0.0
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 

--- a/src/API/API_functions.tsx
+++ b/src/API/API_functions.tsx
@@ -1,4 +1,5 @@
 import { requestAPI } from './handler';
+import { UploadPayload } from '../components/type';
 
 export async function getEnvVariable(varName: string) {
     try {
@@ -17,7 +18,6 @@ export async function setEnvVariable(key: string, value: string) {
             method: 'POST',
             body: JSON.stringify({ key, value })
         });
-        //console.log(data);
     } catch (error) {
         console.error(`Error setting ${key}:`, error);
     }
@@ -25,13 +25,28 @@ export async function setEnvVariable(key: string, value: string) {
 
 export async function testZenodoConnection() {
     try {
-        const data = await requestAPI('zenodo-jupyterlab/test-connection', {
+/*         const data = await requestAPI('zenodo-jupyterlab/test-connection', {
             method: 'GET'
-        });
-        //console.log(data);
+        }); */
+        const data = await requestAPI('zenodo-jupyterlab/zenodo-api', {
+            method: 'POST',
+            body: JSON.stringify({action: 'check-connection'}),
+        })
         return data;
     } catch (error) {
         console.error(`Error testing connection:`, error);
+    }
+}
+
+export async function depositUpload(payload: UploadPayload) {
+    try {
+        const data = await requestAPI('zenodo-jupyterlab/zenodo-api', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        return data;
+    } catch (error) {
+        console.error('Error uploading info:', error);
     }
 }
 
@@ -84,14 +99,18 @@ export async function getServerRootDir() {
     }
 }
 
-/* export async function runPythonCode(code: string) {
+export async function fetchSandboxStatus() {
     try {
-        const data = await requestAPI('zenodo-jupyterlab/code', {
-            method: 'POST',
-            body: JSON.stringify({ code: code })
-        });
-        console.log(data);
+        let response = await fetch('zenodo-jupyterlab/env?env_var=ZENODO_SANDBOX');
+        if (response.ok) {
+            let data = await response.json();
+            return data.ZENODO_SANDBOX;
+        } else {
+            console.error('Failed to fetch sandbox status');
+            return null;
+        }
     } catch (error) {
-        console.error('Error running code:', error);
+        console.error('Error fetching sandbox status:', error);
+        return null;
     }
-} */
+}

--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -159,9 +159,7 @@ const FileBrowser: React.FC<FileBrowserProps> = ({ onSelectFile }) => {
     };
 
     const handleBreadcrumbClick = (path: string) => {
-        console.log('Breadcrumb clicked, path:', path);
         if (path !== currentPath) {
-            //console.log('Updating currentPath from', currentPath, 'to', path);
             setCurrentPath(path);
         }
     };

--- a/src/components/login.tsx
+++ b/src/components/login.tsx
@@ -41,7 +41,21 @@ const useStyles = createUseStyles({
         '&:hover': {
             backgroundColor: '#45a049',
         },
-    }
+    },
+    checkboxContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginBottom: '10px',
+        flexDirection: 'row',
+    },
+    checkboxLabel: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+    checkboxInput: {
+        marginRight: '5px',
+    },
 });
 
 const Login: React.FC = () => {
@@ -50,12 +64,13 @@ const Login: React.FC = () => {
     const[outputData, setOutputData] = useState<string | null>(null);
     const [connectionStatus, setConnectionStatus] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isSandbox, setIsSandbox] = useState(false);
 
     const handleLogin = useCallback(async () => {
         try {
+            await setEnvVariable('ZENODO_SANDBOX', String(isSandbox));
             if (APIKey != '') {
                 await setEnvVariable('ZENODO_API_KEY', APIKey);
-                //console.log(await getEnvVariable('ZENODO_API_KEY'));
                 setOutputData("Zenodo Token Successfully Stored in Environment.");
                 testAPIConnection();
             } else {
@@ -70,13 +85,16 @@ const Login: React.FC = () => {
         } catch (error) {
             console.error(error);
         }
-    }, [APIKey]);
+    }, [APIKey, isSandbox]);
+
+    const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setIsSandbox(event.target.checked);
+    };
 
     const testAPIConnection = async () => {
         setIsLoading(true);
         try {
             var response = await testZenodoConnection();
-            //console.log(response['status']);
             if (Number(response['status']) == 200) {
                 setConnectionStatus("API Connection Successful")
             } else {
@@ -89,25 +107,6 @@ const Login: React.FC = () => {
         }
     }
 
-/*     const handleLogin = () => {
-        try {
-            var code = `
-import os
-            `;
-            if (APIKey != '') {
-                code += `
-os.environ['TESTVAR'] = '${APIKey}'
-                `;
-            }
-            code += `
-os.environ['TESTVAR']
-            `;
-            console.log(code);
-        } catch (error) {
-            alert('Invalid Zenodo API Token');
-        }
-    } */
-
     return (
         <div className={classes.root}>
             <div className={classes.loginContainer}>
@@ -116,6 +115,17 @@ os.environ['TESTVAR']
                     <input className={classes.input} type="text" id="APIKey" name="APIKey" placeholder="API Key" value={APIKey} onChange={(e) => setAPIKey(e.target.value)} required />
         </div>
         <div className={classes.formGroup}>
+            <div className={classes.checkboxContainer}>
+                <label className={classes.checkboxLabel}>
+                    <input
+                        type="checkbox"
+                        checked={isSandbox}
+                        onChange={handleCheckboxChange}
+                        className={classes.checkboxInput}
+                    />
+                    Use Sandbox
+                </label>
+            </div>
             <button className={classes.button} type="submit" onClick={handleLogin}>Login</button>
             {outputData ? (
                 <div>

--- a/src/components/type.tsx
+++ b/src/components/type.tsx
@@ -9,3 +9,19 @@ export interface FileEntry {
 }
 
 export type OnSelectFile = (filePath: string) => void;
+
+export interface Creator {
+    name: string;
+    affiliation?: string;
+}
+
+export interface UploadPayload {
+    title: string;
+    resourceType: string;
+    creators: Creator[];
+    doi: string;
+    description: string;
+    filePaths: string[];
+    isSandbox: boolean;
+    action: string;
+}

--- a/zenodo_jupyterlab/server/extension.py
+++ b/zenodo_jupyterlab/server/extension.py
@@ -6,6 +6,6 @@ def _load_jupyter_server_extension(server_app):
     try:
         setup_handlers(web_app)
         server_app.log.info("Registered zenodo_jupyterlab server extension")
-    except Exception as e:
-        server_app.log.error(f"Failed to register zenodo_jupyterlab server extension: {e}")
+    except:
+        server_app.log.error(f"Failed to register zenodo_jupyterlab server extension")
         raise

--- a/zenodo_jupyterlab/server/testConnection.py
+++ b/zenodo_jupyterlab/server/testConnection.py
@@ -1,13 +1,16 @@
 from eossr.api.zenodo import ZenodoAPI
 import os
 
-#ZenodoHTTPStatus
-
-async def checkZenodoConnection(sandbox: bool):
-    access_token = os.environ['ZENODO_API_KEY']
-    z = ZenodoAPI(access_token=access_token, sandbox = sandbox)
+async def checkZenodoConnection():
     try:
-        response = z.query_user_deposits()
-        return response.status_code
+        access_token = os.environ['ZENODO_API_KEY']
+        env_sandbox = os.environ['ZENODO_SANDBOX']
+        if (env_sandbox == 'true'):
+            sandbox = True
+        else:
+            sandbox = False
+        zAPI = ZenodoAPI(access_token=access_token, sandbox = sandbox)
+        response = zAPI.query_user_deposits()
+        return response.status_code, zAPI
     except:
-        return 0
+        return 0, None

--- a/zenodo_jupyterlab/server/tests/test_testConnection.py
+++ b/zenodo_jupyterlab/server/tests/test_testConnection.py
@@ -15,12 +15,13 @@ async def test_zenodo_connection_success():
     with patch.dict(os.environ, {'ZENODO_API_KEY': os.environ['CI_ZENODO_API_KEY']}):
             with patch.dict(os.environ, {'ZENODO_SANDBOX': "true"}):
                 # Call the function to test
-                status_code = await checkZenodoConnection()
+                status_code, zAPI = await checkZenodoConnection()
 
                 print(f"Returned status code: {status_code}")
 
                 # Assert the expected status code
                 assert status_code == 200
+                assert type(zAPI) == ZenodoAPI
 
 @pytest.mark.asyncio
 async def test_zenodo_connection_failure():
@@ -33,7 +34,8 @@ async def test_zenodo_connection_failure():
     with patch.dict(os.environ, {'ZENODO_API_KEY': 'fake_false_api_key'}):
         with patch.dict(os.environ, {"ZENODO_SANDBOX": 'true'}):
             # Call the function to test
-            status_code = await checkZenodoConnection()
+            status_code, zAPI = await checkZenodoConnection()
 
             # Assert the expected status code
             assert status_code == 0
+            assert zAPI == None

--- a/zenodo_jupyterlab/server/tests/test_testConnection.py
+++ b/zenodo_jupyterlab/server/tests/test_testConnection.py
@@ -15,7 +15,7 @@ async def test_zenodo_connection_success():
     with patch.dict(os.environ, {'ZENODO_API_KEY': os.environ['CI_ZENODO_API_KEY']}):
             with patch.dict(os.environ, {'ZENODO_SANDBOX': "true"}):
                 # Call the function to test
-                status_code = await checkZenodoConnection(sandbox = True)
+                status_code = await checkZenodoConnection()
 
                 print(f"Returned status code: {status_code}")
 
@@ -33,7 +33,7 @@ async def test_zenodo_connection_failure():
     with patch.dict(os.environ, {'ZENODO_API_KEY': 'fake_false_api_key'}):
         with patch.dict(os.environ, {"ZENODO_SANDBOX": 'true'}):
             # Call the function to test
-            status_code = await checkZenodoConnection(sandbox = True)
+            status_code = await checkZenodoConnection()
 
             # Assert the expected status code
             assert status_code == 0

--- a/zenodo_jupyterlab/server/tests/test_testConnection.py
+++ b/zenodo_jupyterlab/server/tests/test_testConnection.py
@@ -13,13 +13,14 @@ async def test_zenodo_connection_success():
 
         # Mock the environment variable
     with patch.dict(os.environ, {'ZENODO_API_KEY': os.environ['CI_ZENODO_API_KEY']}):
-            # Call the function to test
-            status_code = await checkZenodoConnection(sandbox = True)
+            with patch.dict(os.environ, {'ZENODO_SANDBOX': "true"}):
+                # Call the function to test
+                status_code = await checkZenodoConnection(sandbox = True)
 
-            print(f"Returned status code: {status_code}")
+                print(f"Returned status code: {status_code}")
 
-            # Assert the expected status code
-            assert status_code == 200
+                # Assert the expected status code
+                assert status_code == 200
 
 @pytest.mark.asyncio
 async def test_zenodo_connection_failure():
@@ -29,9 +30,10 @@ async def test_zenodo_connection_failure():
     mock_instance.query_user_deposits.side_effect = Exception('Failed') """
 
     # Mock the environment variable
-    with patch.dict('os.environ', {'ZENODO_API_KEY': 'fake_false_api_key'}):
-        # Call the function to test
-        status_code = await checkZenodoConnection(sandbox = True)
+    with patch.dict(os.environ, {'ZENODO_API_KEY': 'fake_false_api_key'}):
+        with patch.dict(os.environ, {"ZENODO_SANDBOX": 'true'}):
+            # Call the function to test
+            status_code = await checkZenodoConnection(sandbox = True)
 
-        # Assert the expected status code
-        assert status_code == 0
+            # Assert the expected status code
+            assert status_code == 0

--- a/zenodo_jupyterlab/server/upload.py
+++ b/zenodo_jupyterlab/server/upload.py
@@ -1,0 +1,38 @@
+
+async def createDeposit(zAPI):
+    response = zAPI.create_new_deposit()
+    return response.json()['id']
+
+async def createMetadata(zAPI, recordID, form_data):
+    title = form_data.get('title')
+    #resource_type = form_data.get('resourceType')
+    #creators = form_data.get('creators')
+    #doi = form_data.get('doi')
+    #description = form_data.get('description')
+    #file_paths = form_data.get('filePaths')
+    #is_sandbox = form_data.get('isSandbox')
+    json_metadata = {
+        'title': title,
+        #'resource_type': {'title': resource_type},
+        #'creators': creators,
+        #'description': description,
+    }
+    """ if doi != '':
+        json_metadata['doi'] = doi """
+    
+    response = zAPI.set_deposit_metadata(recordID, json_metadata)
+    return response
+
+async def upload(zAPI, form_data):
+    if zAPI == None:
+        return None
+    try:
+        recordID = await createDeposit(zAPI)
+        response = await createMetadata(zAPI, str(recordID), form_data)
+        if response != None:
+            return "Success"
+        else:
+            return "Adding the metadata returned a None response."
+    except:
+        return None
+


### PR DESCRIPTION
- Incorporates the connection test and upload into a single ZenodoAPIHandler
- Adds functionality to create new deposits and add titles to the deposit
- creates `ZENODO_SANDBOX` env var that is stored when logging in
> - Logging in can now be done in either sandbox or main Zenodo
> - Whatever the variable contains is displayed in a readonly checkbox above the upload form
- Corrected docker CI to tag PR distributions as dev