### PR TITLE
Add AUTHORS.md file listing contributors to the project

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,8 @@
+# Authors
+
+The list of contributors to the Zenodo JupyterLab Extension in alphabetical order:
+
+- Enrique Garcia
+- Giovanni Guerrieri
+- Michael Zengel
+- Tomas Ondrejka


### PR DESCRIPTION
This pull request adds an AUTHORS.md file to acknowledge contributors to the Zenodo JupyterLab Extension. The contributors are listed in alphabetical order and were sourced from GitHub Insights.