### PR TITLE
chore: Upgrade GitHub Actions Cache to v4 for Improved Performance and Compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '20'
           # cache: 'yarn'
-      
+
           #      - name: Install yarn
           #        run: |
           #          npm install -g corepack
@@ -31,7 +31,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-3.11-${{ hashFiles('package.json') }}
@@ -45,7 +45,7 @@ jobs:
         shell: bash
 
       - name: Setup yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -64,7 +64,7 @@ jobs:
       # - name: Build the Extension
       #   run: jlpm run build
       #   shell: bash
-      
+
       - name: Install Extension
         run: |
           set -eux
@@ -76,14 +76,14 @@ jobs:
           set -eux
           jupyter server extension enable zenodo_jupyterlab.server
         shell: bash
-      
+
       - name: Run Pytest
         env:
           CI_ZENODO_API_KEY: ${{ secrets.CI_ZENODO_API_KEY }}
         run: pytest zenodo_jupyterlab/server/tests
         shell: bash
-      
-      
+
+
   # install_extension:
   #   runs-on: ubuntu-latest
   #   needs: build


### PR DESCRIPTION
This pull request updates the caching mechanism in the GitHub Actions workflow for better performance and compatibility. Specifically, it upgrades the `actions/cache` version used for caching dependencies.

Caching updates in `.github/workflows/build.yaml`:

* Updated the `actions/cache` version from `v2` to `v4` for pip cache setup to leverage improvements in the newer version.
* Updated the `actions/cache` version from `v2` to `v4` for yarn cache setup, ensuring consistency and compatibility across dependency management tools.

Relates-to: #60